### PR TITLE
Add missing dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "bacon": "~0.7.70",
     "react": "~0.13.3",
-    "Keypress": "~2.1.0"
+    "Keypress": "~2.1.0",
+    "bootstrap-grid-css": "e721111dd556b"
   }
 }


### PR DESCRIPTION
bootstrap-grid-css wasn't listed in bower deps
